### PR TITLE
list netty and jackson dependency versions in order to have a unique …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
 
   <properties>
     <stack.version>3.4.0-SNAPSHOT</stack.version>
+    <netty.version>4.1.6.Final</netty.version>
+    <jackson.version>2.7.4</jackson.version>
   </properties>
 
   <dependencyManagement>
@@ -473,6 +475,65 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-discovery-backend-redis</artifactId>
         <version>${stack.version}</version>
+      </dependency>
+
+      <!-- Netty -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-common</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-buffer</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-transport</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-handler-proxy</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-codec-http2</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns</artifactId>
+        <version>${netty.version}</version>
+      </dependency>
+
+      <!-- jackson -->
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-core</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>${jackson.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <stack.version>3.4.0-SNAPSHOT</stack.version>
     <netty.version>4.1.6.Final</netty.version>
     <jackson.version>2.7.4</jackson.version>
+    <tcnative.version>1.1.33.Fork24</tcnative.version>
   </properties>
 
   <dependencyManagement>
@@ -522,6 +523,14 @@
         <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns</artifactId>
         <version>${netty.version}</version>
+      </dependency>
+
+      <!-- netty tc-native -->
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-tcnative-boringssl-static</artifactId>
+        <version>${tcnative.version}</version>
+        <scope>test</scope>
       </dependency>
 
       <!-- jackson -->


### PR DESCRIPTION
…version across all sub projects

A few components such as:

* mongo
* async mysql postgres client
* etc...

use netty as dependency, we all know that in order to things to work as expected the versions of netty should be exactly the same core is using. If this is accepted then we can enforce the version using this BOM instead of manually checking which is always error prone.

Same applies to jackson where many sub projects use it for JSON encoding/decoding.