### PR TITLE
missing vertx-auth-htpasswd dependency added

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -352,6 +352,11 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
+        <artifactId>vertx-auth-htpasswd</artifactId>
+        <version>${stack.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
         <artifactId>vertx-web-parent</artifactId>
         <type>pom</type>
         <version>${stack.version}</version>


### PR DESCRIPTION
can this be pulled into the 3.6 branch for the 3.6.1, thanks