### PR TITLE
Fix security vulnerabilities: jackson-databind 2.9.8 backport 3.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <properties>
     <stack.version>3.6.3-SNAPSHOT</stack.version>
     <netty.version>4.1.30.Final</netty.version>
-    <jackson.version>2.9.7</jackson.version>
+    <jackson.version>2.9.8</jackson.version>
     <tcnative.version>2.0.17.Final</tcnative.version>
   </properties>
 


### PR DESCRIPTION
Fixes
* https://nvd.nist.gov/vuln/detail/CVE-2018-19360
* https://nvd.nist.gov/vuln/detail/CVE-2018-19361
* https://nvd.nist.gov/vuln/detail/CVE-2018-19362
* https://nvd.nist.gov/vuln/detail/CVE-2018-1000873

Complete release notes:
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8

Signed-off-by: Julian Ladisch <julianladisch@users.noreply.github.com>