### PR TITLE
bugfix: for CVE-2019-12814 - upgrade to patched version of jackson-da…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
     <netty.version>4.1.34.Final</netty.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.9.9.1</jackson.version>
     <tcnative.version>2.0.23.Final</tcnative.version>
   </properties>
 


### PR DESCRIPTION
upgrade to patched version of jackson-databind. See https://github.com/FasterXML/jackson-databind/issues/2341 and https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12814 for details.