### PR TITLE
Jackson 2.9.10 fixing 11 databind gadget security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
     <netty.version>4.1.42.Final</netty.version>
-    <jackson.version>2.9.9</jackson.version>
+    <jackson.version>2.9.10</jackson.version>
     <tcnative.version>2.0.26.Final</tcnative.version>
   </properties>
 
@@ -846,7 +846,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.9.9.1</version>
+        <version>${jackson.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Bump the Jackson version from 2.9.9.1 to 2.9.10.
See release notes: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.10

This fixes several jackson-databind gadget type security vulnerabilities,
5 of them have a CVE:
* https://nvd.nist.gov/vuln/detail/CVE-2019-14379
* https://nvd.nist.gov/vuln/detail/CVE-2019-14439
* https://nvd.nist.gov/vuln/detail/CVE-2019-14540
* https://nvd.nist.gov/vuln/detail/CVE-2019-16335
* https://nvd.nist.gov/vuln/detail/CVE-2019-17267

Details:
https://medium.com/@cowtowncoder/on-jackson-cves-dont-panic-here-is-what-you-need-to-know-54cd0d6e8062

Signed-off-by: Julian Ladisch <eclipse.org-rtn@ladisch.de>