### PR TITLE
Remove deps from the BOM that don't exist in the current version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -197,11 +197,6 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-consul</artifactId>
-        <version>${stack.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-consul-client</artifactId>
         <version>${stack.version}</version>
       </dependency>
@@ -209,11 +204,6 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-consul-client</artifactId>
         <type>test-jar</type>
-        <version>${stack.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-mongo</artifactId>
         <version>${stack.version}</version>
       </dependency>
       <dependency>
@@ -261,11 +251,6 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-service-factory</artifactId>
-        <version>${stack.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-maven-service-factory-parent</artifactId>
         <version>${stack.version}</version>
       </dependency>
       <dependency>
@@ -562,11 +547,6 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-mail</artifactId>
-        <version>${stack.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-mail-client</artifactId>
         <version>${stack.version}</version>
       </dependency>
@@ -604,11 +584,6 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-bridge-common</artifactId>
-        <version>${stack.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-jgroups</artifactId>
         <version>${stack.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Signed-off-by: Alexey Loubyansky <olubyans@redhat.com>

Motivation:

The current BOM includes dependencies that don't exist in the current version. They should either be removed completely or the version has to be adjusted to an existing one. In this PR I am simply deleting them. Which may be wrong for all or some of them.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
