### PR TITLE
Upgrade to Netty 4.1.51.Final and netty-tcnative 2.0.33.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
 
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
-    <netty.version>4.1.49.Final</netty.version>
+    <netty.version>4.1.51.Final</netty.version>
     <jackson.version>2.10.2</jackson.version>
-    <tcnative.version>2.0.30.Final</tcnative.version>
+    <tcnative.version>2.0.33.Final</tcnative.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Upgrade netty and netty-tcnative to its latest version which includes for security fixes and AArch64 performance improvements.
Refer release notes for detail:

-https://netty.io/news/2020/05/13/4-1-50-Final.html
-https://netty.io/news/2020/07/09/4-1-51-Final.html

Signed-off-by: odidev <odidev@puresoftware.com>

