### PR TITLE
Update to Netty 4.1.54.Final in order to support MQTT5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
-    <netty.version>4.1.52.Final</netty.version>
+    <netty.version>4.1.53.Final</netty.version>
     <jackson.version>2.10.2</jackson.version>
     <tcnative.version>2.0.30.Final</tcnative.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
-    <netty.version>4.1.49.Final</netty.version>
+    <netty.version>4.1.52.Final</netty.version>
     <jackson.version>2.10.2</jackson.version>
     <tcnative.version>2.0.30.Final</tcnative.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <stack.version>4.0.0-SNAPSHOT</stack.version>
-    <netty.version>4.1.53.Final</netty.version>
+    <netty.version>4.1.54.Final</netty.version>
     <jackson.version>2.11.3</jackson.version>
     <tcnative.version>2.0.30.Final</tcnative.version>
   </properties>


### PR DESCRIPTION
Update Netty to `4.1.52.Final` in order to unlock the work on https://github.com/vert-x3/vertx-mqtt/issues/161.
As far as I can see, Netty has also fixed https://github.com/netty/netty/issues/10499 which was an issue with `4.1.51`.