### PR TITLE
Update to Netty 4.1.52.Final and TcNative 2.0.34.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
 
   <properties>
     <stack.version>4.0.1-SNAPSHOT</stack.version>
-    <netty.version>4.1.56.Final</netty.version>
+    <netty.version>4.1.52.Final</netty.version>
     <jackson.version>2.11.3</jackson.version>
-    <tcnative.version>2.0.35.Final</tcnative.version>
+    <tcnative.version>2.0.34.Final</tcnative.version>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,9 @@
 
   <properties>
     <stack.version>4.0.1-SNAPSHOT</stack.version>
-    <netty.version>4.1.49.Final</netty.version>
+    <netty.version>4.1.56.Final</netty.version>
     <jackson.version>2.11.3</jackson.version>
-    <tcnative.version>2.0.30.Final</tcnative.version>
+    <tcnative.version>2.0.35.Final</tcnative.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
https://github.com/vert-x3/vertx-grpc no longer fails with
recent Netty/TcNative versions, probably because of
https://github.com/vert-x3/vertx-grpc/pull/81

See

- https://github.com/vert-x3/issues/issues/552
- https://github.com/vert-x3/issues/issues/546