### PR TITLE
New web templ vertx-web-templ-jte artifacts missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -456,6 +456,11 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
+        <artifactId>vertx-web-templ-jte</artifactId>
+        <version>${stack.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-httl</artifactId>
         <version>${stack.version}</version>
       </dependency>
@@ -472,6 +477,12 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-freemarker</artifactId>
+        <type>test-jar</type>
+        <version>${stack.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web-templ-jte</artifactId>
         <type>test-jar</type>
         <version>${stack.version}</version>
       </dependency>
@@ -526,6 +537,12 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-freemarker</artifactId>
+        <version>${stack.version}</version>
+        <classifier>shaded</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-web-templ-jte</artifactId>
         <version>${stack.version}</version>
         <classifier>shaded</classifier>
       </dependency>


### PR DESCRIPTION
vertx-web-templ-jte was added to vertx-web  in 4.0.3 however was not referenced in the dependencyManagement of vertx-dependencies