### PR TITLE
build: Bump Jackson from 2.11.3 to 2.11.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <properties>
     <stack.version>4.1.1-SNAPSHOT</stack.version>
     <netty.version>4.1.65.Final</netty.version>
-    <jackson.version>2.11.3</jackson.version>
+    <jackson.version>2.11.4</jackson.version>
     <tcnative.version>2.0.39.Final</tcnative.version>
   </properties>
 


### PR DESCRIPTION
Signed-off-by: Richard Gomez <gomez@localhost.localdomain>

#### Motivation:

This includes a few severity fixes, mainly [CVE-2020-28491](https://nvd.nist.gov/vuln/detail/CVE-2020-28491) which is ostensbly affecting https://github.com/vert-x3/vertx-auth/tree/master/vertx-auth-webauthn