### PR TITLE
backport update netty to 4.1.66.Final (https://github.com/vert-x3/vertx-dependencies/pull/63)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <stack.version>4.1.3-SNAPSHOT</stack.version>
-    <netty.version>4.1.65.Final</netty.version>
+    <netty.version>4.1.66.Final</netty.version>
     <jackson.version>2.11.4</jackson.version>
     <tcnative.version>2.0.39.Final</tcnative.version>
   </properties>


### PR DESCRIPTION
Motivation:

Backport of  [netty 4.1.66.Final - PR](https://github.com/vert-x3/vertx-dependencies/pull/63) in case it is accepted

Would it be fine for you to upgrade it in a patch release?

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
