### PR TITLE
add netty-transport-native-epoll linux-aarch_64 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -958,6 +958,12 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-epoll</artifactId>
+        <version>${netty.version}</version>
+        <classifier>linux-aarch_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-transport-native-kqueue</artifactId>
         <version>${netty.version}</version>
       </dependency>


### PR DESCRIPTION
Motivation:

Compile an aarch64 build without the need to provide the netty version

Using the os-maven plugin, the ideal dependency would look like
```
<dependency>
    <groupId>io.netty</groupId>
    <artifactId>netty-transport-native-epoll</artifactId>
    <classifier>linux-${os.detected.arch}</classifier>
</dependency>
```

_note: it's not possible to depend on multiple architectures for `epoll` as the classes would clash, so as long as they are only in the dependency management it should be fine_