### PR TITLE
add netty-transport-native-kqueue and dns osx-aarch_64 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Vertx-dependencies
 
-image:https://github.com/vert-x3/vertx-dependencies/workflows/CI/badge.svg?branch=master["Build Status", link="https://github.com/vert-x3/vertx-dependencies/actions?query=workflow%3ACI"]
+[![CI](https://github.com/vert-x3/vertx-dependencies/actions/workflows/ci.yml/badge.svg)](https://github.com/vert-x3/vertx-dependencies/actions/workflows/ci.yml)
 
 Defines the versions of the Vert.x components of the stack via dependency managements. It defines the versions of the
 Vert.x components in a single central file.

--- a/pom.xml
+++ b/pom.xml
@@ -975,9 +975,21 @@
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>
+        <artifactId>netty-transport-native-kqueue</artifactId>
+        <version>${netty.version}</version>
+        <classifier>osx-aarch_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
         <artifactId>netty-resolver-dns-native-macos</artifactId>
         <version>${netty.version}</version>
         <classifier>osx-x86_64</classifier>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-resolver-dns-native-macos</artifactId>
+        <version>${netty.version}</version>
+        <classifier>osx-aarch_64</classifier>
       </dependency>
 
       <!-- netty tc-native -->


### PR DESCRIPTION
Motivation:

Compile an aarch64 build on osx without the need to provide the netty version

Using the os-maven plugin, the ideal dependency would look like
```
<dependency>
    <groupId>io.netty</groupId>
    <artifactId>netty-transport-native-kqueue</artifactId>
    <classifier>osx-${os.detected.arch}</classifier>
</dependency>
<dependency>
    <groupId>io.netty</groupId>
    <artifactId>netty-resolver-dns-native-macos</artifactId>
    <classifier>osx-${os.detected.arch}</classifier>
</dependency>
```

_note: it's not possible to depend on multiple architectures for `kqueue`/`dns-native` as the classes would clash, so as long as they are only in the dependency management it should be fine_