### PR TITLE
jackson-databind 2.13.2.1 fixing CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <properties>
     <stack.version>4.3.0-SNAPSHOT</stack.version>
     <netty.version>4.1.74.Final</netty.version>
-    <jackson.version>2.13.1</jackson.version>
+    <jackson.version>2.13.2.20220324</jackson.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
jackson-bom 2.13.2.20220324 ships with the micro-patch jackson-databind 2.13.2.1
that fixes CVE-2020-36518 (StackOverflow exception and denial of service via a
large depth of nested objects):
https://nvd.nist.gov/vuln/detail/CVE-2020-36518
https://repo1.maven.org/maven2/com/fasterxml/jackson/jackson-bom/2.13.2.20220324/jackson-bom-2.13.2.20220324.pom