### PR TITLE
Upgrade netty-bom from 4.1.74.Final to 4.1.77.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <stack.version>4.3.0-SNAPSHOT</stack.version>
-    <netty.version>4.1.74.Final</netty.version>
+    <netty.version>4.1.77.Final</netty.version>
     <jackson.version>2.13.2.20220324</jackson.version>
   </properties>
 


### PR DESCRIPTION
This fixes several bugs:
* https://netty.io/news/2022/03/10/4-1-75-Final.html
* https://netty.io/news/2022/04/12/4-1-76-Final.html
* https://netty.io/news/2022/05/06/2-1-77-Final.html

Netty 4.1.77.Final upgrades netty-tcnative from
2.0.51.Final to 2.0.52.Final fixing bugs and fixing
vulnerability issues in OpenSSL and LibreSSL:

* Upgrade OpenSSL from 1.1.1m to 1.1.1n fixing denial of service
  in BN_mod_sqrt() function: https://nvd.nist.gov/vuln/detail/CVE-2022-0778
* Upgrade LibreSSL from 3.3.5 to 3.4.3 fixing denial of service
  due to malicious certificate:
  https://ftp.openbsd.org/pub/OpenBSD/LibreSSL/libressl-3.4.3-relnotes.txt