### PR TITLE
chore: Update to Netty 4.1.82.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <stack.version>4.1.9-SNAPSHOT</stack.version>
-    <netty.version>4.1.72.Final</netty.version>
+    <netty.version>4.1.82.Final</netty.version>
     <jackson.version>2.11.4</jackson.version>
   </properties>
 


### PR DESCRIPTION
Motivation:

Update to Netty 4.1.82.Final to address https://nvd.nist.gov/vuln/detail/CVE-2022-24823

cherry-pick https://github.com/vert-x3/vertx-dependencies/pull/98

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
