### PR TITLE
Jackson 2.14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <properties>
     <stack.version>4.3.5-SNAPSHOT</stack.version>
     <netty.version>4.1.84.Final</netty.version>
-    <jackson.version>2.13.4</jackson.version>
+    <jackson.version>2.14.0</jackson.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
Upgrade Jackson from 2.13.4 to 2.14.0.

Full change list:
https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14#full-change-list
It contains a security fix:
Fixing Denial of Service (DoS) vulnerability when the non-default UNWRAP_SINGLE_VALUE_ARRAYS feature is enabled: 
https://nvd.nist.gov/vuln/detail/CVE-2022-42003