### PR TITLE
Bump jackson: nothing affecting core, but this version claims to redu…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
   <properties>
     <stack.version>4.4.0-SNAPSHOT</stack.version>
     <netty.version>4.1.85.Final</netty.version>
-    <jackson.version>2.14.0</jackson.version>
+    <jackson.version>2.14.1</jackson.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
…ce memory usage for databind (which isn't used directly by vert.x but used by our end users)

Signed-off-by: Paulo Lopes <pmlopes@gmail.com>

Reduce memory usage for end users that depend on databind.

See: https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.14.1