### PR TITLE
Bump Netty from 4.1.85.Final to 4.1.86.Final fixing CVE-2022-41915

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
 
   <properties>
     <stack.version>4.4.0-SNAPSHOT</stack.version>
-    <netty.version>4.1.85.Final</netty.version>
+    <netty.version>4.1.86.Final</netty.version>
     <jackson.version>2.14.0</jackson.version>
   </properties>
 


### PR DESCRIPTION
This fixes HTTP Response splitting from assigning header value iterator:
https://github.com/netty/netty/security/advisories/GHSA-hh82-3pmq-7frp
https://nvd.nist.gov/vuln/detail/CVE-2022-41915