### PR TITLE
add vertx-openapi to the stack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
+        <artifactId>vertx-openapi</artifactId>
+        <version>${stack.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
         <artifactId>vertx-hazelcast</artifactId>
         <version>${stack.version}</version>
       </dependency>


### PR DESCRIPTION
Motivation:

The new library vertx-openapi must be added to the stack because it is used in vertx-web-openapi.

