### PR TITLE
add vertx-web-openapi-router to the stack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,11 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
+        <artifactId>vertx-web-openapi-router</artifactId>
+        <version>${stack.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.vertx</groupId>
         <artifactId>vertx-web-templ-thymeleaf</artifactId>
         <version>${stack.version}</version>
       </dependency>


### PR DESCRIPTION
Motivation:

`vertx-web-openapi-router` is a new package in vertx-web and needs to be added to the stack