### PR TITLE
Bump guava from 30.1.1-jre to 32.1.2-jre

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -884,7 +884,7 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>30.1.1-jre</version>
+        <version>32.1.2-jre</version>
       </dependency>
 
       <!-- Snake YAML -->


### PR DESCRIPTION
This fixes insecure permissions of files created in the temporary directory: https://nvd.nist.gov/vuln/detail/CVE-2023-2976

Version 32 is binary compatible with version 30 because only the GWT jar has breaking changes:
https://github.com/google/guava/issues/2575#issuecomment-1594317981

I run CI for these repositories and found no regressions:

* vertx-config: https://github.com/julianladisch/vertx-config/actions/runs/6289869333
* vertx-grpc: https://github.com/julianladisch/vertx-grpc/actions/runs/6289478128
* vertx-zookeeper: https://github.com/julianladisch/vertx-zookeeper/actions/workflows/ci-5.x.yml

The failures in vertx-zookeeper are not regressions because they exist with 30.1.1-jre.

I found no other Vert.x repository that uses Guava and hasn't been removed for Vert.x 5.

Obsoletes #118