### PR TITLE
Upgrade to Netty 4.1.100.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
   <properties>
     <stack.version>5.0.0-SNAPSHOT</stack.version>
-    <netty.version>4.1.99.Final</netty.version>
+    <netty.version>4.1.100.Final</netty.version>
     <jackson.version>2.15.0</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>


### PR DESCRIPTION
https://netty.io/news/2023/10/10/4-1-100-Final.html - fixes [CVE-2023-44487](https://nvd.nist.gov/vuln/detail/CVE-2023-44487)