### PR TITLE
upgrade jackson to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
   <properties>
     <stack.version>4.5.1-SNAPSHOT</stack.version>
     <netty.version>4.1.100.Final</netty.version>
-    <jackson.version>2.15.3</jackson.version>
+    <jackson.version>2.16.0</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>
   </properties>


### PR DESCRIPTION
Motivation:

Upgrade jackson to 2.16.0 in order to integrate the new virtual threads friendly resource pool.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
