### PR TITLE
slf4j-bom 2.0.12, log4j-bom 2.23.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
     <stack.version>5.0.0-SNAPSHOT</stack.version>
     <netty.version>4.1.107.Final</netty.version>
     <jackson.version>2.16.1</jackson.version>
-    <slf4j.version>2.0.7</slf4j.version>
-    <log4j2.version>2.17.1</log4j2.version>
+    <slf4j.version>2.0.12</slf4j.version>
+    <log4j2.version>2.23.1</log4j2.version>
   </properties>
 
   <dependencyManagement>
@@ -902,53 +902,19 @@
       <!-- SLF4J version -->
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-api</artifactId>
+        <artifactId>slf4j-bom</artifactId>
         <version>${slf4j.version}</version>
-        <optional>true</optional>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-simple</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-jdk14</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>jcl-over-slf4j</artifactId>
-        <version>${slf4j.version}</version>
-        <scope>test</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- Log4j version -->
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
+        <artifactId>log4j-bom</artifactId>
         <version>${log4j2.version}</version>
-        <optional>true</optional>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${log4j2.version}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
-        <version>${log4j2.version}</version>
-        <scope>test</scope>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
Upgrade slf4j from 2.0.7 to 2.0.12.
Upgrade log4j from 2.17.1 to 2.23.1.

Replace slf4j and log4j dependencies by slf4j-bom and log4j-bom. The boms provide the complete set of slf4j and log4j artifacts with the same version. The incomplete list in vertx-dependencies is useless if another slf4j or log4j artifact is needed.