### PR TITLE
Use GitHub setup-java action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install JDK
-        uses: joschi/setup-jdk@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 8
+          distribution: 'temurin'
       - name: Get project version
         run: echo "PROJECT_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version -B | grep -v '\[')" >> $GITHUB_ENV
       - name: Maven deploy


### PR DESCRIPTION
## Motivation

`joschi/setup-jdk` is obsolete.   The action's repo was archived in December 2022

<img width="687" alt="image" src="https://github.com/vert-x3/vertx-dependencies/assets/30938/1bb8edf4-3693-492c-a4c5-5283c195943b">

The project README recommends using `actions/setup-java`

<img width="470" alt="image" src="https://github.com/vert-x3/vertx-dependencies/assets/30938/59877b5a-70b2-4988-95ff-31efd5a8265d">

## Links

https://github.com/joschi/setup-jdk/blob/main/README.md


## Modifications

replace `joschi/setup-jdk` with standard GitHub Actions `actions/setup-java`

## Conformance

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
