### PR TITLE
(4.x) Upgrade Jackson to 2.18.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
   <properties>
     <stack.version>4.5.14-SNAPSHOT</stack.version>
     <netty.version>4.1.118.Final</netty.version>
-    <jackson.version>2.16.1</jackson.version>
+    <jackson.version>2.18.3</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>
   </properties>


### PR DESCRIPTION
Motivation:

This is a back port of #https://github.com/vert-x3/vertx-dependencies/pull/206 to `4.x` branch.

There is a similar upgrade in wildfly: https://github.com/wildfly/wildfly/pull/18789 which drives this change, so perhaps it would be good to upgrade it in 4.x too.

Conformance:

Your commits should be signed and you should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
