### PR TITLE
[4.x] Update Jackson 2 to 2.21.3 fixing number length DoS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
   <properties>
     <netty.version>4.1.132.Final</netty.version>
-    <jackson.version>2.18.6</jackson.version>
+    <jackson.version>2.21.2</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
   <properties>
     <netty.version>4.1.132.Final</netty.version>
-    <jackson.version>2.21.2</jackson.version>
+    <jackson.version>2.21.3</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>
   </properties>


### PR DESCRIPTION
Bump Jackson from 2.18.6 (EOL) to 2.21.3 (LTS).

This fixes a denial of service vulnerability:
https://github.com/FasterXML/jackson-core/security/advisories/GHSA-72hv-8253-57qq

Release notes:
* https://github.com/FasterXML/jackson-core/blob/jackson-core-2.21.3/release-notes/VERSION-2.x
* https://github.com/FasterXML/jackson-databind/blob/jackson-databind-2.21.3/release-notes/VERSION-2.x

This is a back-port from 5.1 to 4.x.

(cherry picked from commit 85a4d076cdbdd913fd5de011118bae1e616e54aa)
(cherry picked from commit 75d73a3dbacee722ce887bfd1a883d83ae52720a)