### PR TITLE
netty 4.2.13.Final upgrade 5.0

### DIFF
--- a/.github/workflows/ci-5.x-stable.yml
+++ b/.github/workflows/ci-5.x-stable.yml
@@ -1,4 +1,4 @@
-name: CI/CD (5.x-stable)
+name: vertx-dependencies (5.x-stable)
 on:
   push:
     branches:

--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -1,4 +1,4 @@
-name: CI/CD (5.x)
+name: vertx-dependencies (5.x)
 on:
   push:
     branches:

--- a/.github/workflows/ci-matrix-5.x.yml
+++ b/.github/workflows/ci-matrix-5.x.yml
@@ -9,12 +9,12 @@ jobs:
   CI-5_x-Java_11:
     uses: ./.github/workflows/ci.yml
     with:
-      branch: ${{ github.head_ref || github.ref_name }}
+      branch: ${{ inputs.branch }}
       jdk: 11
     secrets: inherit
   CI-5_x-Java_17:
     uses: ./.github/workflows/ci.yml
     with:
-      branch: ${{ github.head_ref || github.ref_name }}
+      branch: ${{ inputs.branch }}
       jdk: 17
     secrets: inherit

--- a/pom.xml
+++ b/pom.xml
@@ -445,13 +445,6 @@
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
-        <artifactId>vertx-web</artifactId>
-        <classifier>client</classifier>
-        <type>js</type>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
         <artifactId>vertx-web-common</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.1</version>
+  <version>5.0.2-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.6</version>
+  <version>5.0.7-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.7-SNAPSHOT</version>
+  <version>5.0.7</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.2</version>
+  <version>5.0.3-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </licenses>
 
   <properties>
-    <netty.version>4.2.2.Final</netty.version>
+    <netty.version>4.2.3.Final</netty.version>
     <jackson.version>2.18.2</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </licenses>
 
   <properties>
-    <netty.version>4.2.1.Final</netty.version>
+    <netty.version>4.2.2.Final</netty.version>
     <jackson.version>2.18.2</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </licenses>
 
   <properties>
-    <netty.version>4.2.7.Final</netty.version>
+    <netty.version>4.2.9.Final</netty.version>
     <jackson.version>2.18.2</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </licenses>
 
   <properties>
-    <netty.version>4.2.4.Final</netty.version>
+    <netty.version>4.2.5.Final</netty.version>
     <jackson.version>2.18.2</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -121,18 +121,18 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-docgen-api</artifactId>
-        <version>0.9.8</version>
+        <version>0.9.9</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-docgen-processor</artifactId>
-        <version>0.9.8</version>
+        <version>0.9.9</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-docgen-processor</artifactId>
         <classifier>processor</classifier>
-        <version>0.9.8</version>
+        <version>0.9.9</version>
       </dependency>
       <dependency>
         <groupId>io.vertx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.3</version>
+  <version>5.0.4-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </licenses>
 
   <properties>
-    <netty.version>4.2.9.Final</netty.version>
+    <netty.version>4.2.10.Final</netty.version>
     <jackson.version>2.18.2</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.3-SNAPSHOT</version>
+  <version>5.0.3</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.5</version>
+  <version>5.0.6-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </licenses>
 
   <properties>
-    <netty.version>4.2.5.Final</netty.version>
+    <netty.version>4.2.7.Final</netty.version>
     <jackson.version>2.18.2</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.2-SNAPSHOT</version>
+  <version>5.0.2</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.4-SNAPSHOT</version>
+  <version>5.0.4</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.6-SNAPSHOT</version>
+  <version>5.0.6</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.1-SNAPSHOT</version>
+  <version>5.0.1</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.4</version>
+  <version>5.0.5-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </licenses>
 
   <properties>
-    <netty.version>4.2.3.Final</netty.version>
+    <netty.version>4.2.4.Final</netty.version>
     <jackson.version>2.18.2</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.7</version>
+  <version>5.0.8-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.5-SNAPSHOT</version>
+  <version>5.0.5</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.8-SNAPSHOT</version>
+  <version>5.0.8</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </licenses>
 
   <properties>
-    <netty.version>4.2.10.Final</netty.version>
+    <netty.version>4.2.11.Final</netty.version>
     <jackson.version>2.18.6</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.10-SNAPSHOT</version>
+  <version>5.0.10</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </licenses>
 
   <properties>
-    <netty.version>4.2.11.Final</netty.version>
+    <netty.version>4.2.12.Final</netty.version>
     <jackson.version>2.18.6</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.10</version>
+  <version>5.0.11-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
 
   <properties>
     <netty.version>4.2.10.Final</netty.version>
-    <jackson.version>2.18.2</jackson.version>
+    <jackson.version>2.18.6</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.8</version>
+  <version>5.0.9-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.9-SNAPSHOT</version>
+  <version>5.0.9</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.9</version>
+  <version>5.0.10-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.11-SNAPSHOT</version>
+  <version>5.0.11</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>vertx-dependencies</artifactId>
-  <version>5.0.11</version>
+  <version>5.0.12-SNAPSHOT</version>
 
   <name>Vert.x Stack - Vert.x components versions</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
   </licenses>
 
   <properties>
-    <netty.version>4.2.12.Final</netty.version>
+    <netty.version>4.2.13.Final</netty.version>
     <jackson.version>2.18.6</jackson.version>
     <slf4j.version>2.0.7</slf4j.version>
     <log4j2.version>2.17.1</log4j2.version>


### PR DESCRIPTION
- **Update of GitHub workflow file for supporting 5.x CI/CD**
- **Update workflow names so they are displayed correctly in badge**
- **Upgrade to Netty 4.2.2**
- **Releasing 5.0.1**
- **Set next snapshot version**
- **Upgrade to Netty 4.2.3**
- **Releasing 5.0.2**
- **Set next snapshot version**
- **Upgrade to Netty 4.2.4.Final**
- **Releasing 5.0.3**
- **Set next snapshot version**
- **Upgrade to Netty 4.2.5.Final**
- **Releasing 5.0.4**
- **Set next snapshot version**
- **Upgrade to Netty 4.2.7.Final**
- **Releasing 5.0.5**
- **Set next snapshot version**
- **Remove modules that no longer exists (#232)**
- **Upgrade to docgen 0.9.9**
- **Upgrade to Netty 4.2.9**
- **Releasing 5.0.6**
- **Set next snapshot version**
- **Releasing 5.0.7**
- **Set next snapshot version**
- **Upgrade to Netty 4.2.10.Final**
- **Releasing 5.0.8**
- **Set next snapshot version**
- **[5.0] Bump jackson from 2.18.2 to 2.18.6 fixing DoS when parsing long number (#242)**
- **Upgrade to Netty 4.2.11.Final**
- **Releasing 5.0.9**
- **Set next snapshot version**
- **Upgrade to Netty 4.2.12.Final**
- **Releasing 5.0.10**
- **Set next snapshot version**
- **Releasing 5.0.11**
- **Set next snapshot version**
- **Update to Netty 4.2.13.Final**

Motivation:

Explain here the context, and why you're making that change, what is the problem you're trying to solve.

Conformance:

You should have signed the Eclipse Contributor Agreement as explained in https://github.com/eclipse/vert.x/blob/master/CONTRIBUTING.md
Please also make sure you adhere to the code style guidelines: https://github.com/vert-x3/wiki/wiki/Vert.x-code-style-guidelines
